### PR TITLE
Added duration of songs to the database

### DIFF
--- a/AudioStreaming/src/main/java/pandora/clone/models/Song.java
+++ b/AudioStreaming/src/main/java/pandora/clone/models/Song.java
@@ -12,11 +12,12 @@ public class Song {
     private String genre = "";
     private String title = "";
     private String track = "";
+    private int duration = 0;
 
     public Song() {
     }
 
-    public Song(int id, String artist, String year, String album, String genre, String title, String track) {
+    public Song(int id, String artist, String year, String album, String genre, String title, String track, int duration) {
         this.id = id;
         this.artist = artist;
         this.year = year;
@@ -24,6 +25,7 @@ public class Song {
         this.genre = genre;
         this.title = title;
         this.track = track;
+        this.duration = duration;
     }
 
     public void setArtist(String artist) {
@@ -80,5 +82,13 @@ public class Song {
 
     public String getTrack() {
         return track;
+    }
+
+    public int getDuration() {
+        return duration;
+    }
+
+    public void setDuration(int duration) {
+        this.duration = duration;
     }
 }

--- a/AudioStreaming/src/main/java/pandora/clone/services/MusicServices.java
+++ b/AudioStreaming/src/main/java/pandora/clone/services/MusicServices.java
@@ -51,6 +51,7 @@ public class MusicServices implements InitializingBean {
 
     public byte[] playSong(String filepath) {
         try {
+            System.out.println("Filepath " + filepath);
             File file = new File(filepath);
             AudioInputStream mp3Stream = AudioSystem.getAudioInputStream(file);
             AudioFormat sourceFormat = mp3Stream.getFormat();
@@ -103,7 +104,7 @@ public class MusicServices implements InitializingBean {
 
         StatementResult result = this.session.run("match (s:Song) where ID(s)={id}" +
                 "return s.filepath as filepath, s.artist as artist, s.year as year," +
-                "s.album as album, s.genre as genre, s.title as title, s.track as track;", parameters("id", id));
+                "s.album as album, s.genre as genre, s.title as title, s.track as track, s.duration as duration;", parameters("id", id));
 
         if (result.hasNext()) {
             Record record = result.next();
@@ -113,7 +114,8 @@ public class MusicServices implements InitializingBean {
                     record.get("album").asString(),
                     record.get("genre").asString(),
                     record.get("title").asString(),
-                    record.get("track").asString());
+                    record.get("track").asString(),
+                    record.get("duration").asInt());
 
             this.playSong(record.get("filepath").asString());
             return s;
@@ -146,7 +148,7 @@ public class MusicServices implements InitializingBean {
 
         StatementResult result = this.session.run("match (s:Song) where ID(s)={id}" +
                 "return s.filepath as filepath, s.artist as artist, s.year as year," +
-                "s.album as album, s.genre as genre, s.title as title, s.track as track;", parameters("id", id));
+                "s.album as album, s.genre as genre, s.title as title, s.track as track, s.duration as duration;", parameters("id", id));
 
         if (result.hasNext()) {
             Record record = result.next();
@@ -156,7 +158,8 @@ public class MusicServices implements InitializingBean {
                     record.get("album").asString(),
                     record.get("genre").asString(),
                     record.get("title").asString(),
-                    record.get("track").asString());
+                    record.get("track").asString(),
+                    record.get("duration").asInt());
 
             this.playSong(record.get("filepath").asString());
             return s;

--- a/AudioStreaming/src/main/java/population/PopulateSongs.java
+++ b/AudioStreaming/src/main/java/population/PopulateSongs.java
@@ -37,14 +37,16 @@ public class PopulateSongs {
                     Mp3File mp3file = new Mp3File(file.getAbsolutePath());
                     if (mp3file.hasId3v1Tag()) {
                         ID3v1 id3v1Tag = mp3file.getId3v1Tag();
-                        session.run("create (s: Song{track: {track}, artist: {artist}, title: {title}, album: {album}, year: {year}, genre: {genre}, filepath: {filepath}})"
-                                , parameters("track", id3v1Tag.getTrack(),
+                        session.run("create (s: Song{track: {track}, artist: {artist}, title: {title}, album: {album}, year: {year}, genre: {genre}, filepath: {filepath}, duration: {duration}})"
+                                , parameters(
+                                        "track", id3v1Tag.getTrack(),
                                         "artist", id3v1Tag.getArtist(),
                                         "title", id3v1Tag.getTitle(),
                                         "album", id3v1Tag.getAlbum(),
                                         "year", id3v1Tag.getYear(),
                                         "genre", id3v1Tag.getGenreDescription(),
-                                        "filepath", file.getAbsolutePath()));
+                                        "filepath", file.getAbsolutePath(),
+                                        "duration", mp3file.getLengthInSeconds()));
                     }
                 } catch (IOException e) {
                     e.printStackTrace();


### PR DESCRIPTION
## Acceptance Criteria
* Everything works on the client side as before
* In the database, the duration of the song is stored.

## How To Test
* Start the application and go to http://localhost:7474/browser/
* Delete any song nodes. Use this command
```
match (s:Song) delete s;
```
* If is fails and you need to get rid of the relationships, use this command, then use the previous command
```
MATCH (n)-[rel:LIKES]->(r) delete rel;
```
* Run the population java application, inside of the AudioStreaming project
* Confirm that the duration is stored by running this command and then inspecting one of the nodes.
```
match (s:Song) return s;
```